### PR TITLE
Potential fix for code scanning alert no. 15: Comparison of narrow type with wide type in loop condition

### DIFF
--- a/zip/ZipLib/extlibs/bzip2/decompress.c
+++ b/zip/ZipLib/extlibs/bzip2/decompress.c
@@ -301,8 +301,9 @@ Int32 BZ2_decompress ( DState* s )
 
       /*--- Undo the MTF values for the selectors. ---*/
       {
-         UChar pos[BZ_N_GROUPS], tmp, v;
-         for (v = 0; v < nGroups; v++) pos[v] = v;
+         UChar pos[BZ_N_GROUPS], tmp;
+         Int32 v;
+         for (v = 0; v < nGroups; v++) pos[v] = (UChar)v;
    
          for (i = 0; i < nSelectors; i++) {
             v = s->selectorMtf[i];


### PR DESCRIPTION
Potential fix for [https://github.com/CPDN-git/cpdn_control/security/code-scanning/15](https://github.com/CPDN-git/cpdn_control/security/code-scanning/15)

Use an `Int32` loop index for the `nGroups`-bounded loop instead of `UChar v`, and only use `UChar` where byte-sized storage is required.  
Best minimal fix in `zip/ZipLib/extlibs/bzip2/decompress.c` around the selector MTF undo block:

- Change local declarations from `UChar pos[BZ_N_GROUPS], tmp, v;` to `UChar pos[BZ_N_GROUPS], tmp; Int32 v;`
- Keep logic unchanged:
  - `for (v = 0; v < nGroups; v++) pos[v] = (UChar)v;`
  - Later uses remain valid (`v = s->selectorMtf[i]; tmp = pos[v]; while (v > 0) ...`)
- No new imports or external dependencies required.

This preserves functionality while ensuring loop-condition operands are same-width.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
