### PR TITLE
Potential fix for code scanning alert no. 14: Multiplication result converted to larger type

### DIFF
--- a/zip/ZipLib/extlibs/zlib/zutil.c
+++ b/zip/ZipLib/extlibs/zlib/zutil.c
@@ -306,9 +306,15 @@ voidpf ZLIB_INTERNAL zcalloc (opaque, items, size)
     unsigned items;
     unsigned size;
 {
+    size_t len;
     if (opaque) items += size - size; /* make compiler happy */
-    return sizeof(uInt) > 2 ? (voidpf)malloc(items * size) :
-                              (voidpf)calloc(items, size);
+    if (sizeof(uInt) > 2) {
+        if (size != 0 && (size_t)items > (size_t)-1 / (size_t)size)
+            return NULL;
+        len = (size_t)items * (size_t)size;
+        return (voidpf)malloc(len);
+    }
+    return (voidpf)calloc(items, size);
 }
 
 void ZLIB_INTERNAL zcfree (opaque, ptr)


### PR DESCRIPTION
Potential fix for [https://github.com/CPDN-git/cpdn_control/security/code-scanning/14](https://github.com/CPDN-git/cpdn_control/security/code-scanning/14)

To fix this safely without changing intended behavior, compute allocation size in `size_t` and guard against overflow before calling `malloc`. The best approach here is:

1. Cast one operand to `size_t` before multiplication so arithmetic is done in the wider type.
2. Add a pre-check: if `size != 0` and `items > (size_t)-1 / size`, return `NULL` (allocation failure), matching allocator failure semantics.
3. Keep the `calloc(items, size)` path unchanged for 16-bit behavior compatibility.

Apply this only in `zip/ZipLib/extlibs/zlib/zutil.c`, inside `zcalloc` (around lines 309–311), replacing the single `malloc(items * size)` expression with guarded `size_t` arithmetic.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
