### PR TITLE
Potential fix for code scanning alert no. 13: Multiplication result converted to larger type

### DIFF
--- a/zip/ZipLib/extlibs/lzma/unix/Ppmd7Enc.c
+++ b/zip/ZipLib/extlibs/lzma/unix/Ppmd7Enc.c
@@ -33,7 +33,7 @@ static void RangeEnc_ShiftLow(CPpmd7z_RangeEnc *p)
 
 static void RangeEnc_Encode(CPpmd7z_RangeEnc *p, UInt32 start, UInt32 size, UInt32 total)
 {
-  p->Low += start * (p->Range /= total);
+  p->Low += (UInt64)start * (p->Range /= total);
   p->Range *= size;
   while (p->Range < kTopValue)
   {


### PR DESCRIPTION
Potential fix for [https://github.com/CPDN-git/cpdn_control/security/code-scanning/13](https://github.com/CPDN-git/cpdn_control/security/code-scanning/13)

To fix this safely without changing behavior, ensure the multiplication is carried out in the same wide type as `p->Low` before addition. The best minimal fix is to cast one multiplicand to `UInt64` (the LZMA codebase uses this typedef), so the whole product is computed in 64-bit arithmetic:

- **File:** `zip/ZipLib/extlibs/lzma/unix/Ppmd7Enc.c`
- **Region:** `RangeEnc_Encode`, line containing `p->Low += start * (p->Range /= total);`
- **Change:** `p->Low += (UInt64)start * (p->Range /= total);`

No new imports or helper methods are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
